### PR TITLE
Fixing initial enrollment count in Course object

### DIFF
--- a/IndividualProject/bugs.txt
+++ b/IndividualProject/bugs.txt
@@ -1,9 +1,10 @@
 Keeping track of bugs to fix:
 
 `Course.java`
-- ennrollStudent(): always returns false (need to check if student can enroll (capacity))
+- Course object enrolledStudentCount starts as 500. Should be initially 0. 
+- ennrollStudent(): always returns false (need to check if student can enroll (doesn't exceed capacity))
 - dropStudent(): always returns false (need to check if there is a student to drop (number of enrolled students not 0))
-- isCourseFull(): should be opposite logic
+- isCourseFull(): returns opposite bool, should be opposite logic
 - getCourseLocation(): returns instructor name instead of course locaion
 - getInstructorName(): returns course locaion instead of instructor name
 - setEnrolledStudentCount(): should not be able to set it below 0. 

--- a/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Course.java
+++ b/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Course.java
@@ -23,7 +23,7 @@ public class Course implements Serializable {
     this.instructorName = instructorName;
     this.courseTimeSlot = timeSlot;
     this.enrollmentCapacity = capacity;
-    this.enrolledStudentCount = 500;
+    this.enrolledStudentCount = 0;
   }
 
   /**


### PR DESCRIPTION
This PR:
Fixes the enrollment count set to 500 initially to initialize count at 0. 